### PR TITLE
Move Omnibus cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.1.0
+* abstracted out packages for cross-platform support later.
+
 ## v0.0.3
 * Remove resource for deprecated template
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,17 @@ end
 ```
 
 Containers do not have to be Chef enabled but it does make them
-extremely easy to configure. The `lxc_container` resource also provides
-`initialize_commands` which an array of commands can be provided
-that will be run after the container is created.
+extremely easy to configure. If you want the Omnibus installer
+cached, you can set the attribute
+
+```ruby
+node['omnibus_updater']['cache_omnibus_installer'] = true
+```
+
+in a role or environment (default is false). The `lxc_container`
+resource also provides `initialize_commands` which an array of
+commands can be provided that will be run after the container is
+created.
 
 ### Repository:
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,3 @@ template '/etc/default/lxc' do
   )
   # notify?
 end
-
-node.set[:omnibus_updater][:cache_omnibus_installer] = true
-include_recipe 'omnibus_updater::deb_downloader'

--- a/recipes/install_dependencies.rb
+++ b/recipes/install_dependencies.rb
@@ -4,3 +4,8 @@ package 'yum' if node[:lxc][:allowed_types].include?('fedora')
 # OpenSuse allowed? Needs zypper (no package available yet!)
 # package 'zypper' if node[:lxc][:allowed_types].include?('opensuse')
 raise 'OpenSuse not currently supported' if node[:lxc][:allowed_types].include?('opensuse')
+
+#store a copy of the Omnibus installer for use by the lxc containers
+if node[:omnibus_updater] && node[:omnibus_updater][:cache_omnibus_installer]
+  include_recipe 'omnibus_updater::deb_downloader'
+end


### PR DESCRIPTION
This moves the Omnibus caching into the install_dependencies recipe and gates it with the attribute rather than setting it in the recipe. My LXC containers may not be using Chef, so I don't want to force this behavior.
