### PR TITLE
restart the lxc-net service when the default template changes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,5 +21,10 @@ template '/etc/default/lxc' do
       :lxc_shutdown_timeout => node[:lxc][:shutdown_timeout]
     }
   )
-  # notify?
+end
+
+#this just reloads the dnsmasq rules when
+service "lxc-net" do
+  action :enable
+  subscribes :restart, resources("template[/etc/default/lxc]")
 end


### PR DESCRIPTION
If you change the lxc network settings via attributes, they don't get picked up unless you restart the lxc-net service.
