### PR TITLE
Add apt-cacher-ng support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.1.0
 * Abstracted out packages for cross-platform support later.
 * Added the 'containers' recipe to create containers for the members of the node['lxc']['containers'] hash
+* Add support for use of the apt::cacher-client settings if a proxy is in use.
 
 ## v0.0.3
 * Remove resource for deprecated template

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Manage linux containers with Chef.
 
 #### default
 
-Installs the packages and configuration files needed for lxc on the server.
+Installs the packages and configuration files needed for lxc on the server. If
+the node uses apt-cacher-ng as a client, the server will be reused when building
+containers.
 
 #### install_dependencies
 

--- a/recipes/install_dependencies.rb
+++ b/recipes/install_dependencies.rb
@@ -1,5 +1,9 @@
-# Fedora allowed? Need yum
-package 'yum' if node[:lxc][:allowed_types].include?('fedora')
+# Fedora allowed? Needs yum and curl to download packages
+if node[:lxc][:allowed_types].include?('fedora')
+  ['yum', 'curl'].each do |pkg|
+    package pkg
+  end
+end
 
 # OpenSuse allowed? Needs zypper (no package available yet!)
 # package 'zypper' if node[:lxc][:allowed_types].include?('opensuse')


### PR DESCRIPTION
Add support for reusing the apt-cacher-ng server if one is present. Also, apparently lxc has a missing dependency on curl.
