### PR TITLE
Fix typo causing the wrong scope to be applied to File.exists? lookup.

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -196,8 +196,12 @@ action :create do
           action :create_if_missing
         end
 
+        # install script requires either curl or wget
         ruby_block "lxc install_chef[#{new_resource.name}]" do
           block do
+            new_resource._lxc.container_command(
+              "apt-get install -y curl"
+            )
             new_resource._lxc.container_command(
               "bash /opt/chef-install.sh"
             )


### PR DESCRIPTION
This addresses issue #18, that I submitted on behalf of SendGrid.
