### PR TITLE
Use Chef::Config to get the default secret file

### DIFF
--- a/resources/container.rb
+++ b/resources/container.rb
@@ -15,7 +15,7 @@ attribute :run_list, :kind_of => Array
 attribute :chef_enabled, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :chef_retries, :kind_of => Fixnum, :default => 0
 attribute :copy_data_bag_secret_file, :kind_of => [TrueClass, FalseClass], :default => false
-attribute :data_bag_secret_file, :kind_of => String, :default => Chef::EncryptedDataBagItem::DEFAULT_SECRET_FILE
+attribute :data_bag_secret_file, :kind_of => String, :default => Chef::Config[:encrypted_data_bag_secret]
 attribute :default_bridge, :kind_of => String
 attribute :static_ip, :kind_of => String
 attribute :static_netmask, :kind_of => String, :default => '255.255.255.0'


### PR DESCRIPTION
Fixes undefined constant problems with Chef 11.6.0 upon convergence.

Fixes Chef not being able to fine the constant as shown in https://gist.github.com/aespinosa/6097207
