### PR TITLE
fixed order of install pkg, then set up /etc/default/lxc

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -64,17 +64,18 @@ elsif(File.exists?('/etc/apt/apt.conf.d/01proxy'))
   end
 end
 
-template '/etc/default/lxc' do
-  source 'default-lxc.erb'
-  mode 0644
-end
-
 include_recipe 'lxc::install_dependencies'
 
 # install the server dependencies to run lxc
 node[:lxc][:packages].each do |lxcpkg|
   package lxcpkg
 end
+
+template '/etc/default/lxc' do
+  source 'default-lxc.erb'
+  mode 0644
+end
+
 
 # this just reloads the dnsmasq rules when the template is adjusted
 service 'lxc-net' do


### PR DESCRIPTION
works around this error ...  alternative would be to set `DPkg::Options=”–force-confold"`  as an apt option,   haven't looked up how to do that.

```
Setting up lxc (0.7.5-3ubuntu67) ...

Configuration file `/etc/default/lxc'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** lxc (Y/I/N/O/D/Z) [default=N] ? 
invoke-rc.d: policy-rc.d denied execution of start.
lxc-net start/running
```
