### PR TITLE
use upstart on ubuntu > 13.10

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,13 +82,19 @@ node[:lxc][:packages].each do |lxcpkg|
   end
 end
 
+# use upstart on ubuntu > saucy
+service_provider = Chef::Provider::Service::Upstart if 'ubuntu' == node['platform'] &&
+  Chef::VersionConstraint.new('>= 13.10').include?(node['platform_version'])
+
 # this just reloads the dnsmasq rules when the template is adjusted
 service 'lxc-net' do
+  provider service_provider
   action [:enable, :start]
   subscribes :restart, resources("template[/etc/default/lxc]")
 end
 
 service 'lxc' do
+  provider service_provider
   action [:enable, :start]
 end
 


### PR DESCRIPTION
Borrowed from opscode-cookbooks/openssh#30: Use upstart provider for services on Ubuntu > 13.10
