### PR TITLE
Stop lxc-net being started on every chef run

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -8,6 +8,7 @@ service 'lxc-net' do
   action [:enable, :start]
   subscribes :restart, 'file[/etc/default/lxc]'
   only_if{ node.platform_family?('debian') }
+  supports [:restart, :status]
 end
 
 service 'lxc' do


### PR DESCRIPTION
By adding this chef won't try start the service on every run, but rather
check to see if it's running first.