### PR TITLE
Execute lxc default_password_scrub when needed

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -206,7 +206,7 @@ action :create do
         end
       end
     end
-#    not_if "grep 'root:\*' #{_lxc.rootfs.join('etc/shadow').to_path}"
+    not_if "grep 'root:\*' #{_lxc.rootfs.join('etc/shadow').to_path}"
   end
 
   ruby_block "lxc start[#{new_resource.name}]" do


### PR DESCRIPTION
default_password_scrub run every time chef runs, which is annoying since
we report our resource updates to a campfire room. This stops that from
happening on every run.

This was commented out in https://github.com/hw-cookbooks/lxc/commit/32558eb4f5195960ece726415294c895b6a446cd, but I'm not 100% sure why.