### PR TITLE
Do not start lxc-net service if it does not exist

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,6 +8,7 @@ end
 
 dpkg_autostart 'lxc-net' do
   allow false
+  only_if{ node.platform_family?('debian') and File.exist?("/etc/default/lxc-net") }
 end
 
 include_recipe 'lxc::install_dependencies'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -7,7 +7,7 @@ service 'lxc-net' do
   provider service_provider
   action [:enable, :start]
   subscribes :restart, 'file[/etc/default/lxc]'
-  only_if{ node.platform_family?('debian') }
+  only_if{ node.platform_family?('debian') and File.exist?("/etc/default/lxc-net") }
   supports [:restart, :status]
 end
 


### PR DESCRIPTION
My debian jessie does not have lxc-net service. I do not need to start it.